### PR TITLE
Disable dependabot for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Dependabot was generating a lot of PRs that were failing CI. I am not super familiar with how python `requirements.txt` works so I am disabling it for now until I have a better plan of how to update and maintain dependencies.