### PR TITLE
Improve workflows

### DIFF
--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -1,8 +1,9 @@
-name: Upgrade Python Dependencies
+name: Upgrade Dependencies
 
 on:
     schedule:
         - cron: '0 13 * * 6'
+    workflow_dispatch: # Allow the workflow to be started manually
 
 jobs:
     upgrade-deps:
@@ -16,6 +17,14 @@ jobs:
               uses: actions/setup-python@v3
               with:
                 python-version: 3.10
+
+            - name: Cache pip dependencies
+              uses: actions/cache@v3
+              with:
+                path: ~/.cache/pip
+                key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+                restore-keys: |
+                  ${{ runner.os }}-pip-
                 
             - name: Upgrade Dependencies
               run: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -27,7 +27,7 @@ jobs:
       run: python -c "import sys; print(sys.version)"
 
     - name: Cache pip dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -39,11 +39,11 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Check formatting
+      run: |
+        python -m black . --check
+
     - name: Run unit tests
       run: |
         cd src
         python -m unittest
-
-    - name: Check formatting
-      run: |
-        python -m black . --check


### PR DESCRIPTION
Add a caching layer to the dependency update workflow
Update the version of the dependent actions used
Make the dependency update workflow able to be triggered manually