### PR TITLE
More changes to the update dependencies workflow

### DIFF
--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -25,6 +25,10 @@ jobs:
                 key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
                 restore-keys: |
                   ${{ runner.os }}-pip-
+
+            - name: Upgrade Pip
+              run: |
+                python -m pip install --upgrade pip
                 
             - name: Upgrade Dependencies
               run: |
@@ -32,18 +36,9 @@ jobs:
                 python -m pip install --upgrade -r requirements.txt
                 python -m pip freeze > requirements.txt
 
-            - name: Check for changes
-              id: check_changes
+            - name: Print Changes
               run: |
-                git diff --quiet
-                echo "::set-output name=has_changes::$(git diff --quiet || echo true)"
-
-            - name: Exit if no changes
-              run: |
-                if [ "${{ steps.check_changes.outputs.has_changes }}" != "true" ]; then
-                  echo "No changes found. Exiting without creating a pull request."
-                  exit 0
-                fi
+                git diff
 
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
The Create PR action will automatically detect no changes so we don't need a separate step for that
Update pip before doing anything else
Print the full diff so we can see what versions update