### PR TITLE
Use the github workflow token instead of a custom token

### DIFF
--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v3
               with:
-                token: ${{ secrets.UPDATE_DEPS_TOKEN }}
+                token: ${{ secrets.GITHUB_TOKEN }}
                 base: main
                 branch: upgrade-dependencies
                 branch-suffix: timestamp


### PR DESCRIPTION
I did not realize that there was a default token to use for the github actions bot. Let's use that instead of a custom token that I saved in the secrets.