### PR TITLE
Switch back to a PAT

### DIFF
--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Create Pull Request
               uses: peter-evans/create-pull-request@v3
               with:
-                token: ${{ secrets.GITHUB_TOKEN }}
+                token: ${{ secrets.UPDATE_DEPS_TOKEN }}
                 base: main
                 branch: upgrade-dependencies
                 branch-suffix: timestamp


### PR DESCRIPTION
Using the default `GITHUB_TOKEN` means that workflows will not automatically run on the PR that is created. Switch back to an access token so that the workflows will run.