### PR TITLE
Don't run the upgrade script on a cron any more

### DIFF
--- a/.github/workflows/upgrade_deps.yml
+++ b/.github/workflows/upgrade_deps.yml
@@ -1,9 +1,6 @@
 name: Upgrade Dependencies
 
-on:
-  schedule:
-    - cron: '0 13 * * 6'
-  workflow_dispatch: # Allow the workflow to be started manually
+on: workflow_dispatch
 
 jobs:
   upgrade-deps:


### PR DESCRIPTION
Seems a little excessive to run it every week just to upgrade boto. Turning off the cron, it can still be run manually.