### PR TITLE
Lower min GLSL version

### DIFF
--- a/src/shader/fragment.glsl
+++ b/src/shader/fragment.glsl
@@ -1,4 +1,4 @@
-#version 460
+#version 330
 
 #define MAX_SCANS 20
 

--- a/src/shader/vertex.glsl
+++ b/src/shader/vertex.glsl
@@ -1,4 +1,4 @@
-#version 460
+#version 330
 
 // Vertex inputs
 in vec4 p3d_Vertex;


### PR DESCRIPTION
I don't actually need the GLSL version to be so high. Lowering it to 3.30 is a step toward supporting Mac.