### PR TITLE
Depend on pynexrad from pypi instead of building from github directly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ blosc>=1.11.1
 numpy>=1.26.3
 panda3d>=1.10.13
 platformdirs>=4.1.0
-pynexrad@git+https://github.com/jtfedd/pynexrad.git
+pynexrad==0.0.13
 requests>=2.31.0
 timezonefinder>=6.2.0
 tzdata>=2023.4


### PR DESCRIPTION
Benefits:
- Consumers don't have to build the wheel directly
- The wheel is built in release mode and the code is much faster