### PR TITLE
Change badge font to make it easier to read

### DIFF
--- a/src/lib/ui/core/components/badge.py
+++ b/src/lib/ui/core/components/badge.py
@@ -36,7 +36,7 @@ class Badge(Component):
 
         self.text = Text(
             root=root,
-            font=ctx.fonts.black,
+            font=ctx.fonts.bold,
             text=text,
             x=x,
             y=y,


### PR DESCRIPTION
`black` was a little too much, going back to `bold`