### PR TITLE
Model optimization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.26.4
 panda3d==1.10.14
 panda3d-gltf>=1.2.0
 platformdirs>=4.2.2
-pynexrad==0.0.16
+pynexrad==0.0.18
 requests>=2.32.3
 tzdata>=2024.1
 tzfpy>=0.15.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy>=1.26.4
 panda3d==1.10.14
 panda3d-gltf>=1.2.0
 platformdirs>=4.2.2

--- a/src/lib/network/radar/provider.py
+++ b/src/lib/network/radar/provider.py
@@ -1,7 +1,6 @@
 import datetime
 from typing import List
 
-import numpy as np
 import pynexrad
 
 from lib.model.record import Record
@@ -30,7 +29,7 @@ def scanDataFromScan(scan: pynexrad.Scan) -> ScanData:
     offset = 0
     for meta in scan.sweeps:
         sweeps.append(sweepMetaFromSweep(meta, offset))
-        data += np.array(meta.data, dtype=np.float32).tobytes()
+        data += bytearray(meta.data)
         offset += len(meta.data)
 
     return ScanData(sweeps, data)

--- a/src/lib/render_volume/volume_data_provider.py
+++ b/src/lib/render_volume/volume_data_provider.py
@@ -95,9 +95,9 @@ class VolumeDataProvider(Listener):
 
     def setupBuffer(self) -> None:
         self.buffer.setupBufferTexture(
-            int(self.bufferSize / 4),  # buffer size is in bytes
-            Texture.T_float,
-            Texture.F_r32,
+            int(self.bufferSize),
+            Texture.T_unsigned_byte,
+            Texture.F_r8i,
             GeomEnums.UH_dynamic,
         )
 

--- a/src/shaders/fragment_sharp.glsl
+++ b/src/shaders/fragment_sharp.glsl
@@ -31,7 +31,7 @@ uniform int offset[MAX_SCANS];
 
 uniform float density_params[7];
 
-uniform samplerBuffer volume_data;
+uniform usamplerBuffer volume_data;
 
 uniform float ambient_intensity;
 uniform float directional_intensity;

--- a/src/shaders/fragment_smooth.glsl
+++ b/src/shaders/fragment_smooth.glsl
@@ -31,7 +31,7 @@ uniform int offset[MAX_SCANS];
 
 uniform float density_params[7];
 
-uniform samplerBuffer volume_data;
+uniform usamplerBuffer volume_data;
 
 uniform float ambient_intensity;
 uniform float directional_intensity;

--- a/src/shaders/gen/fragment_sharp.glsl
+++ b/src/shaders/gen/fragment_sharp.glsl
@@ -31,7 +31,7 @@ uniform int offset[MAX_SCANS];
 
 uniform float density_params[7];
 
-uniform samplerBuffer volume_data;
+uniform usamplerBuffer volume_data;
 
 uniform float ambient_intensity;
 uniform float directional_intensity;
@@ -154,7 +154,11 @@ float data_value_for_sweep(vec3 point, int sweep_index) {
     }
 
     int buff_index = r_count[sweep_index] * az_index + r_index;
-    return texelFetch(volume_data, offset[sweep_index] + buff_index).x;
+    int value = int(texelFetch(volume_data, offset[sweep_index] + buff_index).x);
+    if (value == 0.0) {
+        return -1.0;
+    }
+    return float(value - 1) / 254.0;
 }
 
 float data_value(vec3 point) {

--- a/src/shaders/gen/fragment_smooth.glsl
+++ b/src/shaders/gen/fragment_smooth.glsl
@@ -31,7 +31,7 @@ uniform int offset[MAX_SCANS];
 
 uniform float density_params[7];
 
-uniform samplerBuffer volume_data;
+uniform usamplerBuffer volume_data;
 
 uniform float ambient_intensity;
 uniform float directional_intensity;
@@ -150,7 +150,11 @@ float interpolate(float low, float high, float factor) {
 
 float data_value_for_indices(int sweep_index, int az_index, int r_index) {
     int buff_index = r_count[sweep_index] * az_index + r_index;
-    return texelFetch(volume_data, offset[sweep_index] + buff_index).x;
+    int value = int(texelFetch(volume_data, offset[sweep_index] + buff_index).x);
+    if (value == 0.0) {
+        return -1.0;
+    }
+    return (value - 1.0) / 254.0;
 }
 
 float data_value_for_gate(vec3 point, int sweep_index, int r_index) {

--- a/src/shaders/volume_sharp.part.glsl
+++ b/src/shaders/volume_sharp.part.glsl
@@ -24,7 +24,11 @@ float data_value_for_sweep(vec3 point, int sweep_index) {
     }
 
     int buff_index = r_count[sweep_index] * az_index + r_index;
-    return texelFetch(volume_data, offset[sweep_index] + buff_index).x;
+    int value = int(texelFetch(volume_data, offset[sweep_index] + buff_index).x);
+    if (value == 0.0) {
+        return -1.0;
+    }
+    return float(value - 1) / 254.0;
 }
 
 float data_value(vec3 point) {

--- a/src/shaders/volume_smooth.part.glsl
+++ b/src/shaders/volume_smooth.part.glsl
@@ -20,7 +20,11 @@ float interpolate(float low, float high, float factor) {
 
 float data_value_for_indices(int sweep_index, int az_index, int r_index) {
     int buff_index = r_count[sweep_index] * az_index + r_index;
-    return texelFetch(volume_data, offset[sweep_index] + buff_index).x;
+    int value = int(texelFetch(volume_data, offset[sweep_index] + buff_index).x);
+    if (value == 0.0) {
+        return -1.0;
+    }
+    return (value - 1.0) / 254.0;
 }
 
 float data_value_for_gate(vec3 point, int sweep_index, int r_index) {

--- a/src/test/testutils/models.py
+++ b/src/test/testutils/models.py
@@ -2,8 +2,6 @@ import datetime
 import random
 import unittest
 
-import numpy as np
-
 from lib.model.record import Record
 from lib.model.scan import Scan
 from lib.model.scan_data import ScanData
@@ -40,7 +38,7 @@ def newTestSweepMeta() -> SweepMeta:
 def newTestScanData() -> ScanData:
     return ScanData(
         [newTestSweepMeta() for _ in range(10)],
-        np.random.uniform(low=0, high=1, size=1000).astype(np.float32).tobytes(),
+        random.randbytes(1000),
     )
 
 


### PR DESCRIPTION
Consumes the updated data model which uses bytes instead of floats. This means the buffer texture passed to the shader can be roughly 1/4 the size.