### PR TITLE
Refactor logging

### DIFF
--- a/src/config/app.prc
+++ b/src/config/app.prc
@@ -1,0 +1,8 @@
+# App Configuration
+
+# Set the window title and icon
+window-title 3D Radar Viewer
+icon-filename assets/icon/icon.ico
+
+# Set the gl version for compatibility with mac
+gl-version 3 2

--- a/src/config/logging.prc
+++ b/src/config/logging.prc
@@ -1,0 +1,2 @@
+# Logging configuration
+notify-level-file_manager info

--- a/src/config/logging.prc
+++ b/src/config/logging.prc
@@ -1,2 +1,9 @@
 # Logging configuration
+# By default any loggers created will be enabled for "warning"
+# Individual loggers can be overridden here
+
 notify-level-file_manager info
+notify-level-task_manager info
+notify-level-location_provider info
+notify-level-nws_service info
+nofity-level-radar_provider info

--- a/src/lib/app/files/manager.py
+++ b/src/lib/app/files/manager.py
@@ -3,11 +3,11 @@ import json
 from pathlib import Path
 from typing import Dict
 
-from direct.directnotify.DirectNotify import DirectNotify
 from direct.stdpy import threading
 from platformdirs import user_cache_dir, user_config_dir
 
 from lib.app.events import AppEvents
+from lib.app.logging import newLogger
 from lib.app.state import AppState
 from lib.util.events.listener import Listener
 
@@ -25,7 +25,7 @@ class FileManager(Listener):
     def __init__(self, state: AppState, events: AppEvents) -> None:
         super().__init__()
 
-        self.log = DirectNotify().newCategory("file_manager")
+        self.log = newLogger("file_manager")
 
         self._clearPreviousDirs()
 

--- a/src/lib/app/logging.py
+++ b/src/lib/app/logging.py
@@ -1,0 +1,6 @@
+from direct.directnotify.DirectNotify import DirectNotify
+from direct.directnotify.Notifier import Notifier
+
+
+def newLogger(name: str) -> Notifier:
+    return DirectNotify().newCategory(name)

--- a/src/lib/app/task/manager.py
+++ b/src/lib/app/task/manager.py
@@ -5,12 +5,16 @@ from direct.showbase.ShowBase import ShowBase
 from direct.stdpy import threading
 from direct.task.Task import Task
 
+from lib.app.logging import newLogger
+
 from .task import AbstractTask
 from .task_status import TaskStatus
 
 
 class TaskManager:
     def __init__(self, base: ShowBase) -> None:
+        self.log = newLogger("task_manager")
+
         self.maxThreads = max(os.cpu_count() or 1, 1)
         self.activeThreads = 0
         self.activeThreadsLock = threading.Lock()
@@ -19,12 +23,12 @@ class TaskManager:
         self.tasks: List[AbstractTask] = []
         self.tasksLock = threading.Lock()
 
-        print("max threads", self.maxThreads)
+        self.log.info(f"max threads {self.maxThreads}")
 
         self.updateTask = base.taskMgr.add(self.update, "task-update")
 
     def addTask(self, task: AbstractTask) -> None:
-        print("add task", task.name())
+        self.log.info(f"add task {task.name()}")
         with self.tasksLock:
             self.tasks.append(task)
 
@@ -62,13 +66,13 @@ class TaskManager:
         return task.cont
 
     def processTask(self, t: AbstractTask) -> None:
-        print("process task", t.name())
+        self.log.info(f"process task {t.name()}")
 
         thread = threading.Thread(target=self.runTask, daemon=True, args=(t,))
         thread.start()
 
     def runTask(self, t: AbstractTask) -> None:
-        print("run task", t.name())
+        self.log.info(f"run task {t.name()}")
         try:
             t.process()
         finally:

--- a/src/lib/network/location/provider.py
+++ b/src/lib/network/location/provider.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from lib.app.logging import newLogger
 from lib.model.location import Location
 
 from ..util import makeRequest
@@ -8,8 +9,11 @@ from ..util import makeRequest
 class LocationProvider:
     HOST = "https://nominatim.openstreetmap.org"
 
+    def __init__(self) -> None:
+        self.log = newLogger("location_provider")
+
     def search(self, address: str, limit: int = 1) -> List[Location] | None:
-        print("Searching", address)
+        self.log.info(f"Searching {address}")
 
         response = makeRequest(
             self.HOST + "/search",

--- a/src/lib/network/radar/provider.py
+++ b/src/lib/network/radar/provider.py
@@ -3,6 +3,7 @@ from typing import List
 
 import pynexrad
 
+from lib.app.logging import newLogger
 from lib.model.record import Record
 from lib.model.scan import Scan
 from lib.model.scan_data import ScanData
@@ -44,10 +45,13 @@ def scanFromLevel2File(record: Record, file: pynexrad.Level2File) -> Scan:
 
 
 class RadarProvider:
+    def __init__(self) -> None:
+        self.log = newLogger("radar_provider")
+
     def load(self, record: Record) -> Scan:
         key = record.awsKey()
 
-        print("Fetching from s3:", key)
+        self.log.info(f"Fetching from s3: {key}")
 
         level2File = pynexrad.download_nexrad_file(
             record.station,
@@ -57,7 +61,7 @@ class RadarProvider:
             key,
         )
 
-        print("Post-processing", key)
+        self.log.info(f"Post-processing {key}")
         return scanFromLevel2File(record, level2File)
 
     def search(self, record: Record, count: int) -> List[Record]:

--- a/src/lib/services/nws/nws_service.py
+++ b/src/lib/services/nws/nws_service.py
@@ -1,6 +1,7 @@
 from typing import Dict, List
 
 from lib.app.files.manager import FileManager
+from lib.app.logging import newLogger
 from lib.model.alert import Alert
 from lib.model.alert_type import AlertType
 from lib.model.radar_station import RadarStation
@@ -9,6 +10,8 @@ from lib.network.network import Network
 
 class NWSService:
     def __init__(self, fileManager: FileManager, network: Network) -> None:
+        self.log = newLogger("nws_service")
+
         self.network = network
         self.fileManager = fileManager
 
@@ -21,7 +24,7 @@ class NWSService:
         return self.radarStations[stationID]
 
     def preloadStations(self) -> Dict[str, RadarStation]:
-        print("Loading stations from NWS")
+        self.log.info("Loading stations from NWS")
         stations = self.network.nws.getRadarStations()
         if stations:
             return stations

--- a/src/main.py
+++ b/src/main.py
@@ -1,16 +1,11 @@
 from direct.showbase.ShowBase import ShowBase
-from panda3d.core import loadPrcFileData
+from panda3d.core import loadPrcFile
 
 from lib.app.app import App
 
-CONFIG = """
-gl-version 3 2
-window-title 3D Radar Viewer
-icon-filename assets/icon/icon.ico
-"""
-
 if __name__ == "__main__":
-    loadPrcFileData("", CONFIG)
+    loadPrcFile("config/app.prc")
+    loadPrcFile("config/logging.prc")
 
     base = ShowBase()
     app = App(base)


### PR DESCRIPTION
Use panda3d log methods instead of prints.

This allows different modules to be turned on and off. It also fixes issues with threading and print statements.