### PR TITLE
Loading progress modal

### DIFF
--- a/src/lib/app/data_manager/loading_task.py
+++ b/src/lib/app/data_manager/loading_task.py
@@ -4,6 +4,8 @@ from lib.app.context import AppContext
 from lib.model.data_query import DataQuery
 from lib.model.record import Record
 from lib.model.scan import Scan
+from lib.util.events.event_dispatcher import EventDispatcher
+from lib.util.events.observable import Observable
 
 from .load_data_task import LoadDataTask
 from .load_records_task import LoadRecordsTask
@@ -18,12 +20,17 @@ class LoadingTask:
         loadCompleteCallback: Callable[
             [DataQuery, List[Record], Dict[str, Scan]], None
         ],
+        loadCancelledCallback: Callable[[], None],
     ) -> None:
         self.cancelled = False
+        self.onComplete = EventDispatcher[None]()
+
+        self.progress = Observable[float](0.0)
 
         self.ctx = ctx
         self.getCachedScan = getCachedScan
         self.loadCompleteCallback = loadCompleteCallback
+        self.loadCancelledCallback = loadCancelledCallback
         self.dataQuery = dataQuery
 
         self.loadRecordsTask = LoadRecordsTask(
@@ -34,16 +41,30 @@ class LoadingTask:
         )
         self.ctx.taskManager.addTask(self.loadRecordsTask)
 
+        self.tasksComplete = 0
         self.loadDataTasks: List[LoadDataTask] = []
 
         self.resultRecords: List[Record] = []
         self.resultScans: Dict[str, Scan] = {}
 
+    def updateProgress(self) -> None:
+        if len(self.loadDataTasks) == 0:
+            self.progress.setValue(0.0)
+            return
+
+        self.progress.setValue(self.tasksComplete / len(self.loadDataTasks))
+
     def cancel(self) -> None:
+        if self.cancelled:
+            return
+
         self.cancelled = True
+        self.onComplete.send(None)
         self.loadRecordsTask.cancel()
         for task in self.loadDataTasks:
             task.cancel()
+
+        self.loadCancelledCallback()
 
     def onListRecordsComplete(self, records: List[Record]) -> None:
         if self.cancelled:
@@ -54,7 +75,7 @@ class LoadingTask:
         for record in records:
             cachedScan = self.getCachedScan(record.key())
             if cachedScan is not None:
-                self.onLoadFileComplete(cachedScan)
+                self.addResultScan(cachedScan)
                 continue
 
             loadDataTask = LoadDataTask(
@@ -66,7 +87,15 @@ class LoadingTask:
             self.ctx.taskManager.addTask(loadDataTask)
             self.loadDataTasks.append(loadDataTask)
 
+        self.updateProgress()
+
     def onLoadFileComplete(self, scan: Scan) -> None:
+        self.tasksComplete += 1
+        self.updateProgress()
+
+        self.addResultScan(scan)
+
+    def addResultScan(self, scan: Scan) -> None:
         if self.cancelled:
             return
 
@@ -78,5 +107,7 @@ class LoadingTask:
     def onLoadComplete(self) -> None:
         if self.cancelled:
             return
+
+        self.onComplete.send(None)
 
         self.loadCompleteCallback(self.dataQuery, self.resultRecords, self.resultScans)

--- a/src/lib/model/loading_progress_payload.py
+++ b/src/lib/model/loading_progress_payload.py
@@ -1,0 +1,16 @@
+from typing import Callable
+
+from lib.util.events.event_dispatcher import EventDispatcher
+from lib.util.events.observable import Observable
+
+
+class LoadingProgressPayload:
+    def __init__(
+        self,
+        progress: Observable[float],
+        onComplete: EventDispatcher[None],
+        cancel: Callable[[], None],
+    ) -> None:
+        self.progress = progress
+        self.onComplete = onComplete
+        self.cancel = cancel

--- a/src/lib/ui/core/constants.py
+++ b/src/lib/ui/core/constants.py
@@ -119,6 +119,9 @@ class UIConstants:
     alertModalWidth = 1.2
     alertModalMaxHeight = 1.0
 
+    loadingProgressModalWidth = 0.8
+    loadingProgressModalHeight = 0.25
+
     labelPadding = 0.01
 
     # Higher number means slower scrolling

--- a/src/lib/ui/modals/events.py
+++ b/src/lib/ui/modals/events.py
@@ -1,4 +1,5 @@
 from lib.model.alert import Alert
+from lib.model.loading_progress_payload import LoadingProgressPayload
 from lib.model.location import Location
 from lib.util.events.event_dispatcher import EventDispatcher
 
@@ -19,6 +20,8 @@ class ModalEvents:
         self.alerts = EventDispatcher[None]()
         self.alert = EventDispatcher[Alert]()
 
+        self.loadingProgress = EventDispatcher[LoadingProgressPayload]()
+
     def destroy(self) -> None:
         self.stationSearch.close()
         self.stationSelected.close()
@@ -33,3 +36,5 @@ class ModalEvents:
 
         self.alerts.close()
         self.alert.close()
+
+        self.loadingProgress.close()

--- a/src/lib/ui/modals/loading_progress/modal.py
+++ b/src/lib/ui/modals/loading_progress/modal.py
@@ -1,0 +1,69 @@
+from lib.app.events import AppEvents
+from lib.model.loading_progress_payload import LoadingProgressPayload
+from lib.ui.context import UIContext
+from lib.ui.core.alignment import HAlign
+from lib.ui.core.components.progress_bar import ProgressBar
+from lib.ui.core.constants import UIConstants
+from lib.ui.core.layers import UILayer
+from lib.util.events.listener import Listener
+
+from ..core.footer_button import FooterButton
+from ..core.modal import Modal
+from ..core.title import ModalTitle
+
+
+class LoadingProgressModal(Modal):
+    def __init__(
+        self,
+        ctx: UIContext,
+        events: AppEvents,
+        payload: LoadingProgressPayload,
+    ):
+        super().__init__(
+            ctx,
+            events,
+            UIConstants.loadingProgressModalWidth,
+            UIConstants.loadingProgressModalHeight,
+        )
+
+        self.listener = Listener()
+
+        self.title = ModalTitle(
+            ctx,
+            self.topLeft,
+            "Loading Data...",
+            UIConstants.loadingProgressModalWidth,
+        )
+
+        self.progressBar = ProgressBar(
+            self.topLeft,
+            x=UIConstants.modalPadding,
+            y=-(self.title.height() + UIConstants.modalPadding),
+            width=UIConstants.loadingProgressModalWidth
+            - (2 * UIConstants.modalPadding),
+            hAlign=HAlign.LEFT,
+            progress=0,
+            layer=UILayer.MODAL_CONTENT_INTERACTION,
+            bgLayer=UILayer.MODAL_CONTENT,
+        )
+
+        self.cancelButton = FooterButton(
+            ctx,
+            self.bottomLeft,
+            UIConstants.loadingProgressModalWidth,
+            "Cancel",
+        )
+
+        self.listener.listen(
+            self.cancelButton.button.onClick, lambda _: payload.cancel()
+        )
+        self.listener.bind(payload.progress, self.progressBar.setProgress)
+        self.listener.listen(payload.onComplete, lambda _: self.destroy())
+
+    def destroy(self) -> None:
+        super().destroy()
+        self.listener.destroy()
+
+        self.title.destroy()
+        self.progressBar.destroy()
+        self.cancelButton.destroy()

--- a/src/lib/ui/modals/manager.py
+++ b/src/lib/ui/modals/manager.py
@@ -1,6 +1,7 @@
 from lib.app.events import AppEvents
 from lib.app.state import AppState
 from lib.ui.context import UIContext
+from lib.ui.modals.loading_progress.modal import LoadingProgressModal
 from lib.util.events.listener import Listener
 
 from .alert.modal import AlertModal
@@ -46,6 +47,11 @@ class ModalManager(Listener):
         self.listen(
             events.ui.modals.alert,
             lambda alert: self.openModal(AlertModal(ctx, events, alert)),
+        )
+
+        self.listen(
+            events.ui.modals.loadingProgress,
+            lambda payload: self.openModal(LoadingProgressModal(ctx, events, payload)),
         )
 
     def openModal(self, modal: Modal) -> None:


### PR DESCRIPTION
Show a progress modal when loading data that the user selected.

This makes it much nicer to see how far the progress is and allows the user to cancel if they decided it's going to take too long or they want to look at a different view.