### PR TITLE
Fix issue where panels are sometimes not immediately scrollable

### DIFF
--- a/src/lib/ui/panels/core/panel_component_manager.py
+++ b/src/lib/ui/panels/core/panel_component_manager.py
@@ -18,6 +18,7 @@ class PanelComponentManager:
         self.subscriptions.append(
             component.onHeightChange.listen(lambda _: self.update())
         )
+        self.update()
 
     def update(self) -> None:
         height = 0.0


### PR DESCRIPTION
# Problem

Sometimes a panel is not immediately scrollable and some other UI update must be performed before the panel can be scrolled.

# Solution

Update the panel scroller height as components are added.