### PR TITLE
Add listener trigger functions

### DIFF
--- a/src/lib/util/events/listener.py
+++ b/src/lib/util/events/listener.py
@@ -26,6 +26,21 @@ class Listener:
         callback(observable.getValue())
         self.listen(observable, callback)
 
+    def trigger(
+        self,
+        dispatcher: EventDispatcher[T],
+        callback: Callable[[], None],
+    ) -> None:
+        self.subscriptions.append(dispatcher.listen(lambda _: callback()))
+
+    def triggerMany(  # type: ignore
+        self,
+        dispatchers: List[EventDispatcher[Any]],
+        callback: Callable[[], None],
+    ) -> None:
+        for dispatcher in dispatchers:
+            self.trigger(dispatcher, callback)
+
     def destroy(self) -> None:
         for sub in self.subscriptions:
             sub.cancel()

--- a/src/lib/util/events/listener.py
+++ b/src/lib/util/events/listener.py
@@ -30,16 +30,20 @@ class Listener:
         self,
         dispatcher: EventDispatcher[T],
         callback: Callable[[], None],
+        triggerImmediately: bool = False,
     ) -> None:
+        if triggerImmediately:
+            callback()
         self.subscriptions.append(dispatcher.listen(lambda _: callback()))
 
     def triggerMany(  # type: ignore
         self,
         dispatchers: List[EventDispatcher[Any]],
         callback: Callable[[], None],
+        triggerImmediately: bool = False,
     ) -> None:
         for dispatcher in dispatchers:
-            self.trigger(dispatcher, callback)
+            self.trigger(dispatcher, callback, triggerImmediately=triggerImmediately)
 
     def destroy(self) -> None:
         for sub in self.subscriptions:

--- a/src/test/util/events/test_listener.py
+++ b/src/test/util/events/test_listener.py
@@ -1,0 +1,105 @@
+import unittest
+
+from lib.util.events.event_dispatcher import EventDispatcher
+from lib.util.events.listener import Listener
+from lib.util.events.observable import Observable
+
+
+class TestListener(unittest.TestCase):
+    def testListenerListen(self) -> None:
+        listener = Listener()
+        event = EventDispatcher[int]()
+
+        x = 0
+
+        def onEvent(value: int) -> None:
+            nonlocal x
+            x = value
+
+        listener.listen(event, onEvent)
+
+        event.send(10)
+        self.assertEqual(x, 10)
+
+        event.send(100)
+        self.assertEqual(x, 100)
+
+        listener.destroy()
+
+        event.send(1000)
+        self.assertEqual(x, 100)
+
+    def testListenerBind(self) -> None:
+        listener = Listener()
+        observable = Observable[int](5)
+
+        x = 0
+
+        def onEvent(value: int) -> None:
+            nonlocal x
+            x = value
+
+        listener.bind(observable, onEvent)
+        self.assertEqual(x, 5)
+
+        observable.send(10)
+        self.assertEqual(x, 10)
+
+        observable.send(100)
+        self.assertEqual(x, 100)
+
+        listener.destroy()
+
+        observable.send(1000)
+        self.assertEqual(x, 100)
+
+    def testListenerTrigger(self) -> None:
+        listener = Listener()
+        event = EventDispatcher[None]()
+
+        callCount = 0
+
+        def onEvent() -> None:
+            nonlocal callCount
+            callCount += 1
+
+        listener.trigger(event, onEvent)
+
+        event.send(None)
+        self.assertEqual(callCount, 1)
+
+        event.send(None)
+        self.assertEqual(callCount, 2)
+
+        listener.destroy()
+
+        event.send(None)
+        self.assertEqual(callCount, 2)
+
+    def testListenerTriggerMany(self) -> None:
+        listener = Listener()
+        event1 = EventDispatcher[None]()
+        event2 = EventDispatcher[None]()
+
+        callCount = 0
+
+        def onEvent() -> None:
+            nonlocal callCount
+            callCount += 1
+
+        listener.triggerMany([event1, event2], onEvent)
+
+        event1.send(None)
+        self.assertEqual(callCount, 1)
+
+        event2.send(None)
+        self.assertEqual(callCount, 2)
+
+        event1.send(None)
+        self.assertEqual(callCount, 3)
+
+        listener.destroy()
+
+        event1.send(None)
+        event2.send(None)
+        self.assertEqual(callCount, 3)


### PR DESCRIPTION
Sometimes I want to just trigger a function on an event and I don't care what the payload is. This could also be useful for triggering on multiple events with different value types.