### PR TITLE
Add additional permissions necessary for the test job

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -87,6 +87,9 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
For PRs created from forks additional permissions are necessary for the test job.