### PR TITLE
Remove coverage

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -25,15 +25,6 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
 
-    #   - name: Publish Unit Test Coverage
-    #     uses: zgosalvez/github-actions-report-lcov@v4
-    #     with:
-    #       coverage-files: artifacts/reports/coverage.lcov
-    #       artifact-name: code-coverage-report
-    #       minimum-coverage: 0
-    #       github-token: ${{ secrets.GITHUB_TOKEN }}
-    #       update-comment: true
-
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -97,15 +97,9 @@ jobs:
             requirements.txt
             requirements-dev.txt
       - run: make install-dev
-      - name: Setup LCOV
-        uses: hrishikesh-kadam/setup-lcov@v1
-      - name: Run Unit Tests With Coverage
-        run: make test-xml-coverage
+      - name: Run Unit Tests
+        run: make test-xml
         continue-on-error: true
-      - name: Generate LCOV report
-        run: |
-          make coverage-lcov
-          sed -i "s;$PWD/;;g" reports/coverage.lcov
       - name: Publish Reports
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -65,29 +65,9 @@ packages-check: ## Check for packages with a missing __init__ file
 test: ## Run tests
 	cd src && python -m unittest
 
-.PHONY: test-coverage
-test-coverage: ## Run tests and generate coverage report
-	cd src && python -m coverage run --source=lib --data-file=../reports/.coverage -m unittest
-
 .PHONY: test-xml
 test-xml: ## Run unit tests and generate xml reports
 	cd src && python -m xmlrunner -o ../reports
-
-.PHONY: test-xml-coverage
-test-xml-coverage:  ## Run unit tests and generate xml reports and coverage report
-	cd src && python -m coverage run --source=lib --data-file=../reports/.coverage -m xmlrunner -o ../reports
-
-.PHONY: coverage-report
-coverage-report: ## Print the coverage report from a previous test coverage run
-	cd reports && python -m coverage report
-
-.PHONY: coverage-html
-coverage-html: ## Generate html coverage report from a previous test coverage run
-	cd reports && python -m coverage html
-
-.PHONY: coverage-lcov
-coverage-lcov: ## Generage lcov report from a previous test coverage run
-	cd reports && python -m coverage lcov
 
 .PHONY: maps
 maps: ## Download and generate maps

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 black>=24.8.0
-coverage>=7.6.1
 flake8>=7.1.1
 isort>=5.13.2
 mypy>=1.11.2

--- a/src/lib/network/radar/provider.py
+++ b/src/lib/network/radar/provider.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import List
 
-import pynexrad
+from pynexrad import PyLevel2File, PySweep, download_nexrad_file, list_records
 
 from lib.app.logging import newLogger
 from lib.model.record import Record
@@ -9,7 +9,7 @@ from lib.model.scan import Scan
 from lib.model.sweep import Sweep
 
 
-def convertSweep(sweep: pynexrad.Sweep) -> Sweep:
+def convertSweep(sweep: PySweep) -> Sweep:
     return Sweep(
         sweep.elevation,
         sweep.az_first,
@@ -24,11 +24,11 @@ def convertSweep(sweep: pynexrad.Sweep) -> Sweep:
     )
 
 
-def convertSweeps(sweeps: List[pynexrad.Sweep]) -> List[Sweep]:
+def convertSweeps(sweeps: List[PySweep]) -> List[Sweep]:
     return [convertSweep(sweep) for sweep in sweeps]
 
 
-def convertLevel2File(record: Record, file: pynexrad.Level2File) -> Scan:
+def convertLevel2File(record: Record, file: PyLevel2File) -> Scan:
     return Scan(
         record,
         convertSweeps(file.reflectivity),
@@ -45,7 +45,7 @@ class RadarProvider:
 
         self.log.info(f"Fetching from s3: {key}")
 
-        level2File = pynexrad.download_nexrad_file(key)
+        level2File = download_nexrad_file(key)
 
         self.log.info(f"Post-processing {key}")
         return convertLevel2File(record, level2File)
@@ -113,7 +113,7 @@ class RadarProvider:
         return records
 
     def getScans(self, radar: str, year: int, month: int, day: int) -> List[Record]:
-        resp = pynexrad.list_records(radar, year, month, day)
+        resp = list_records(radar, year, month, day)
 
         records = []
 


### PR DESCRIPTION
Addresses https://github.com/jtfedd/3d-radar/issues/162

I had unit test coverage reported on PRs but given that it was extremely hard to test ui components I had very little coverage. Rather than try to port the coverage reporting to the `workflow_run` action I am just removing it. If it brings value to add it back in the future it should not be hard to do.

The tests are still running and can be used where they are helpful but they will no longer report code coverage.

This should also make the test runs faster 😄 